### PR TITLE
Simplify/clean up navbar, simplify footer, change routes

### DIFF
--- a/static/realistikosu.css
+++ b/static/realistikosu.css
@@ -11,8 +11,7 @@
 */
 
 /* Custom Font Imports */
-@import url('https://fonts.googleapis.com/css2?family=KoHo:wght@300&family=Niramit&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Montserrat&family=Raleway:wght@300;400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
 
 .rank-sh, .rank-ssh { color:#CDE7E7; }
 .rank-s, .rank-ss { color:#FC2; }
@@ -53,7 +52,8 @@
 }
 
 a:hover {
-    text-decoration: underline;
+    text-decoration: none;
+    color: rgb(148 163 184);
 }
 
 .container-bar {
@@ -90,7 +90,16 @@ a:hover {
 }
 
 * {
-    font-family: 'Montserrat', sans-serif;
+    font-family: 'Poppins', sans-serif;
+    font-weight: 400;
+}
+
+b {
+    font-weight: 600;
+}
+
+.active {
+    font-weight: 600 !important;
 }
 
 body {
@@ -98,9 +107,9 @@ body {
     overflow-x: hidden;
 }
 
-h1, h2, h3, h4, h5, h6, .header .ui.header {
+/* h1, h2, h3, h4, h5, h6, .header .ui.header {
     font-family: 'KoHo', sans-serif;
-}
+} */
 
 .ripple.logo {
 	padding-top: 4px;
@@ -795,14 +804,17 @@ img.locked-achievement:hover {
 	font-size: 25px; color: white;
 }
 .footer-bg {
-    background: #212121;
-    height: 180px;
+    background: rgb(24, 24, 24);
+    height: 3.5em;
     margin: 10px 0 -30px!important;
-    padding: 25px 0 0;
+    padding: 15px 20px;
     text-align: center;
     flex: 0 0 auto;
     left: 0;
     bottom: 0;
+    align-items: center;
+    color: #FFF;
+    display: flex;
 }
 .ui.stackable.four.grid{
 	margin-top: 3px;
@@ -1362,4 +1374,11 @@ td:last-child {
 .noUi-connect {
     background: #54C8FF !important;
     box-shadow: 0 0 0 2px #54C8FF inset !important;
+}
+
+.item {
+    font-style: normal;
+    font-weight: 500;
+    font-size: 14px;
+    line-height: 16px;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -132,48 +132,11 @@
 		</div>
 
 		<div class="footer-bg">
-			<div class="ui container">
-				<div class="ui internally celled grid">
-					<div class="row">
-						<div class="three wide column">
-							<div class="footer-info-block">
-								<a class="footer-title">Help</a> 
-								<ul style="list-style-type: none; padding: 0; margin: 0;">
-									<li>
-										<a href="/static/ROS.exe">Server Switcher</a>
-									</li>
-								</ul>
-							</div> 
-						</div>
-						<div class="three wide column">
-							<div class="footer-info-block">
-								<a class="footer-title">Social</a>
-								<ul style="list-style-type: none; padding: 0; margin: 0;">
-									<li>
-										<a href="https://discord.gg/8ySdzhyMtt" target="_blank">Discord</a>
-									</li>
-								</ul>
-							</div>
-						</div>
-						<div class="seven wide column">
-							<div class="footer-info-block">
-								<a class="footer-title">Source Code</a>
-								<ul style="list-style-type: none; padding: 0; margin: 0;">
-									<li>
-										<a href="https://github.com/RealistikOsu" target="_blank">GitHub</a>
-									</li>
-								</ul>
-							</div>
-						</div>
-						<div class="footer-logo">
-							<span style="color: white; font-size: 30px;">RealistikOsu!</span> 
-							<br>
-							<a class="subtitle" style="font-size: 15px; color: white;">osu! private server</a><br>
-							<a href="https://topg.org/osu-private-servers/server-599427" style="margin-top:5px"><img src="/static/image/vote.png" alt="Vote RealistikOsu!"></a>
-						</div>
-					</div>
-				</div>
+			<div class="ui container centered">
+				© 2023 Realistik! Not affiliated with "ppy" and "osu!" in any way.
+				<a href="https://github.com/RealistikOsu"><i class="fa-brands fa-github"></i> Github</a>
 			</div>
+		</div>
 		{{/* If we got some more scripts to print, print'em */}}
 		<script src="//twemoji.maxcdn.com/2/twemoji.min.js?2.2"></script>
 		<script src="/static/timeago-locale/jquery.timeago.en.js"></script>

--- a/templates/beatmap_listing.html
+++ b/templates/beatmap_listing.html
@@ -1,5 +1,5 @@
 {{/*###
-Handler=/bmaps_listing
+Handler=/beatmap_listing
 TitleBar=Beatmap Listing
 KyutGrill=leaderboard2.jpg
 */}}

--- a/templates/clans/clan_settings.html
+++ b/templates/clans/clan_settings.html
@@ -1,17 +1,15 @@
 {{/* prettier-ignore-start */}}
 {{/*###
-Handler=/settings/clan
-TitleBar=Clan
+Handler=/clan/manage
+TitleBar=Manage Clan
 Settings KyutGrill=settings2.jpg
-Include=menu.html
 */}}
 {{/* prettier-ignore-end */}}
 {{ define "tpl" }}
   {{ $ := . }}
   <div class="ui container">
     <div class="ui stackable grid">
-      {{ template "settingsSidebar" . }}
-      <div class="twelve wide column">
+      <div class="centered twelve wide column">
         <div class="ui segment">
           {{ $d := qb "SELECT user, clan, perms FROM user_clans WHERE user = ? AND perms = 8 LIMIT 1" .Context.User.ID }}
           {{ $g := or $d.clan.Int -1 }}

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -6,7 +6,7 @@
 	<img navbar class="navbar-image" id="navimg" src="/static/images/navbar.png">
 	<div class="ui container responsive">
 		<div class="item">
-			<b><a href="/" title="{{ .T "Home page" }}"><img class="ripple logo" alt="RealistikOsu!" style="max-height: 35px;" src="/static/images/new-logo.svg"></a></b>
+			<a href="/" title="{{ .T "Home Page" }}"><img class="ripple logo" alt="Realistik!" style="max-height: 35px;" src="/static/images/new-logo.svg"></a>
 		</div>
 		{{ if $isRAP }}
 			{{/*
@@ -16,44 +16,48 @@
 				the current RAP's sidebar.
 			*/}}
 		{{ else }}
+			{{ navbarItem .Path (.T "Leaderboard") "/leaderboard" }}
 			<div class="ui dropdown item">
-				<span class="text">
-					<i class='fa-solid fa-trophy'></i>&nbsp; {{ .T "Leaderboard" }}
-				</span>
+				<span>{{ .T "Clan" }}</span>
 				<div class="menu">
-					{{ navbarItem .Path (.T "PP/Score Leaderboard") "/leaderboard" }}
-					{{ navbarItem .Path (.T "Clan Leaderboard") "/clanboard" }}
+					{{ if .Context.User.Username }}
+						{{ $isClan := qb "SELECT user, clan FROM user_clans WHERE user = ?" .Context.User.ID }}
+						{{ $clanOwner := qb "SELECT 1 FROM user_clans WHERE user = ? AND perms = 8 LIMIT 1" .Context.User.ID }}
+						{{ if $isClan }}
+							{{ navbarItem .Path (.T "My Clan") ($isClan.clan | printf "/c/%s") }}
+							{{ if $clanOwner }}
+								{{ navbarItem .Path (.T "Manage Clan") "/clan/manage" }}
+							{{ end }}
+						{{ else }}
+							{{ navbarItem .Path (.T "Create Clan") "/clans/create" }}
+						{{ end }}
+					{{ end }}
+					{{ navbarItem .Path (.T "Leaderboard") "/clanboard" }}
 				</div>
 			</div>
-			{{ navbarItem .Path (.T "Score Feed" | printf "<i class='fa-solid fa-rss'></i>&nbsp; %s") "/scores" }}
 			<div class="ui dropdown item">
-				<span class="text">
-					<i class="fa-solid fa-circle-info"></i>&nbsp; {{ .T "Help" }}
-				</span>
+				<span>{{ .T "Support" }}</span>
 				<div class="menu">
-					{{ navbarItem .Path (.T "About") "/about" }}
 					{{ navbarItem .Path (.T "Rules") "/doc/rules" }}
-					{{ navbarItem .Path (.T "Server Switcher (Deprecated)") "/static/ROS.exe" }}
+					{{ navbarItem .Path (.T "Documentation") "/doc" }}
+					{{ navbarItem .Path (.T "Connection Guide") "/connect" }}
 					{{ navbarItem .Path (.T "Our Team") "/team" }}
 				</div>
 			</div>
-			{{ if .Context.User.Username }}
-				<div class="ui dropdown item">
-					<span class="text">
-						<i class="fa-solid fa-layer-group"></i>&nbsp; {{ .T "Beatmaps" }}
-					</span>
-					<div class="menu">
-						{{ navbarItem .Path (.T "Request Beatmap Ranking") "/rank_request" }}
-						{{ navbarItem .Path (.T "Beatmaps Listing") "/bmaps_listing" }}		
-					</div>
+			<div class="ui dropdown item">
+				<span>{{ .T "Beatmaps" }}</span>
+				<div class="menu">
+					{{ navbarItem .Path (.T "Beatmap Listing") "/beatmap_listing" }}
+					{{ if .Context.User.Username }}
+						{{ navbarItem .Path (.T "Request Beatmap") "/rank_request" }}
+					{{ end }}
 				</div>
-				{{ navbarItem .Path (.T "Donate" | printf "<i class='fa-solid fa-heart'></i>&nbsp; %s") "/donate" }}
-			{{ end }}
-			{{ if $isAdmin }}
-				{{ navbarItem .Path (.T "Admin Panel" | printf "<i class='fa-solid fa-toolbox'></i>&nbsp; <b>%s</b>") "https://old.ussr.pl" }}
-			{{ end }}
+			</div>
 		{{ end }}
 		<div class="firetrucking-right-menu">
+			{{ if .Context.User.Username }}
+				{{ navbarItem .Path (.T "❤ Support us!") "/donate" }}
+			{{ end }}
 			<div class="item">
 				<div class="ui search" id="user-search">
 					<div class="ui icon input">
@@ -64,11 +68,17 @@
 			</div>
 			{{ if .Context.User.Username }}
 				<div class="ui dropdown item">
-					<img id="avatar" class="ui avatar image" src="{{ config "AvatarURL" }}/{{ .Context.User.ID }}">
+					<div style="display: flex; gap: 9px; align-items: center;">
+						<span>{{ .T "Hi" }} <b>{{ .Context.User.Username }}</b></span>
+						<img id="avatar" class="ui avatar image" src="{{ config "AvatarURL" }}/{{ .Context.User.ID }}">
+					</div>
 					<div class="menu">
 						{{ navbarItem .Path (.T "Profile") (printf "/u/%d" .Context.User.ID) }}
 						{{ navbarItem .Path (.T "Friends") "/friends" }}
 						{{ navbarItem .Path (.T "Settings") "/settings" }}
+						{{ if $isAdmin }}
+							{{ navbarItem .Path (.T "Admin Panel" | printf "<b>%s</b>") "https://old.ussr.pl" }}
+						{{ end }}
 						{{ navbarItem .Path (.T "Log out") (printf "/logout?k=%s" (.Session.Get "logout")) }}
 					</div>
 				</div>


### PR DESCRIPTION
Hey, this PR contains following changes.

- Simplified/cleaned up navbar (previously links were all over the place)
- Simplified footer (previously footer was very buggy and bloated)
- Routes change on following templates: beatmap_listing and clan settings
- Fonts changed from KoHo and Montserrat to Poppins