### PR TITLE
feat(settings): add Twitch account linking

### DIFF
--- a/env.example
+++ b/env.example
@@ -46,6 +46,14 @@ DISCORD_APP_CLIENT_ID=your-discord-client-id
 DISCORD_APP_CLIENT_SECRET=your-discord-client-secret
 DISCORD_USER_LOOKUP_URL=https://discord.com/api/v10/users/
 
+# Twitch Settings
+# Powers /settings/twitch, which links a player's Twitch channel for the beatmap
+# request bot. Optional: leave blank to hide the feature rather than break boot.
+# Create an application at https://dev.twitch.tv/console/apps and set its OAuth
+# redirect URL to <SOUMETSU_BASE_URL>/settings/twitch/redirect
+TWITCH_APP_CLIENT_ID=
+TWITCH_APP_CLIENT_SECRET=
+
 # External Links
 GITHUB_ORG_URL=https://github.com/RealistikOsu
 

--- a/internal/adapters/twitch/oauth.go
+++ b/internal/adapters/twitch/oauth.go
@@ -1,0 +1,152 @@
+// Package twitch wraps the parts of the Twitch OAuth2 flow needed to link a
+// Soumetsu account to a Twitch channel: exchange an authorization code for an
+// access token, then fetch the authenticated Twitch user. The flow is entirely
+// server-side and the access token is used once and discarded — we only ever
+// need the channel's immutable numeric ID and its current login name.
+//
+// Mirrors internal/adapters/discord, which does the same job for Discord.
+package twitch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	authorizeURL = "https://id.twitch.tv/oauth2/authorize"
+	tokenURL     = "https://id.twitch.tv/oauth2/token"
+	usersURL     = "https://api.twitch.tv/helix/users"
+)
+
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+}
+
+type usersResponse struct {
+	Data []struct {
+		ID              string `json:"id"`
+		Login           string `json:"login"`
+		DisplayName     string `json:"display_name"`
+		ProfileImageURL string `json:"profile_image_url"`
+	} `json:"data"`
+}
+
+// User is the subset of the Twitch user object we persist alongside the link.
+type User struct {
+	// ID is Twitch's numeric user ID. It never changes, even if the channel is
+	// renamed, so it is what the link is keyed on.
+	ID string
+	// Login is the lowercase channel name — what appears in twitch.tv/<login>
+	// and what the chat bot joins.
+	Login           string
+	DisplayName     string
+	ProfileImageURL string
+}
+
+// AuthorizeURL builds the URL the user is sent to so Twitch can prompt them to
+// authorise the link.
+//
+// No scopes are requested: reading the authenticated user's own ID and login
+// needs none, and asking for more than that would be an unnecessary grant.
+func AuthorizeURL(clientID, redirectURI, state string) string {
+	q := url.Values{
+		"client_id":     {clientID},
+		"redirect_uri":  {redirectURI},
+		"response_type": {"code"},
+		"scope":         {""},
+		"state":         {state},
+	}
+	return authorizeURL + "?" + q.Encode()
+}
+
+// ExchangeCode swaps the authorization code Twitch redirected us with for an
+// access token. redirectURI must match the one sent in the authorize URL.
+func ExchangeCode(ctx context.Context, httpClient *http.Client, clientID, clientSecret, code, redirectURI string) (string, error) {
+	form := url.Values{
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("twitch token exchange: status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tr tokenResponse
+	if err := json.Unmarshal(body, &tr); err != nil {
+		return "", err
+	}
+	if tr.AccessToken == "" {
+		return "", fmt.Errorf("twitch token exchange: empty access_token")
+	}
+	return tr.AccessToken, nil
+}
+
+// FetchUser returns the Twitch account that authorised the given access token.
+//
+// Helix requires the Client-ID header alongside the bearer token; omitting it is
+// a 401 even when the token itself is valid.
+func FetchUser(ctx context.Context, httpClient *http.Client, clientID, accessToken string) (User, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, usersURL, nil)
+	if err != nil {
+		return User{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Client-Id", clientID)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return User{}, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return User{}, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return User{}, fmt.Errorf("twitch user fetch: status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var ur usersResponse
+	if err := json.Unmarshal(body, &ur); err != nil {
+		return User{}, err
+	}
+	if len(ur.Data) == 0 || ur.Data[0].ID == "" {
+		return User{}, fmt.Errorf("twitch user fetch: no user in response")
+	}
+
+	u := ur.Data[0]
+	return User{
+		ID:              u.ID,
+		Login:           u.Login,
+		DisplayName:     u.DisplayName,
+		ProfileImageURL: u.ProfileImageURL,
+	}, nil
+}

--- a/internal/api/handlers/twitch.go
+++ b/internal/api/handlers/twitch.go
@@ -1,0 +1,346 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/RealistikOsu/soumetsu/internal/adapters/twitch"
+	apicontext "github.com/RealistikOsu/soumetsu/internal/api/context"
+	"github.com/RealistikOsu/soumetsu/internal/api/middleware"
+	"github.com/RealistikOsu/soumetsu/internal/api/response"
+	"github.com/RealistikOsu/soumetsu/internal/config"
+	"github.com/RealistikOsu/soumetsu/internal/models"
+	"github.com/RealistikOsu/soumetsu/internal/repositories"
+)
+
+const twitchOAuthStateKey = "twitch_oauth_state"
+
+// Bounds for the star rating filter. The upper bound is generous rather than
+// exact — it only needs to reject nonsense, not track the hardest ranked map.
+const (
+	maxStarRating = 20.0
+	maxCooldown   = 3600
+)
+
+// TwitchHandler serves the Twitch linking and beatmap-request settings pages.
+//
+// Unlike Discord linking — which delegates the code exchange to soumetsu-api —
+// this flow runs entirely in-process against the database, because the request
+// settings it manages are owned by the bot's schema rather than the API.
+type TwitchHandler struct {
+	config     *config.Config
+	repo       *repositories.TwitchRepository
+	csrf       middleware.CSRFService
+	store      middleware.SessionStore
+	templates  *response.TemplateEngine
+	httpClient *http.Client
+}
+
+func NewTwitchHandler(
+	cfg *config.Config,
+	repo *repositories.TwitchRepository,
+	csrf middleware.CSRFService,
+	store middleware.SessionStore,
+	templates *response.TemplateEngine,
+) *TwitchHandler {
+	return &TwitchHandler{
+		config:     cfg,
+		repo:       repo,
+		csrf:       csrf,
+		store:      store,
+		templates:  templates,
+		httpClient: http.DefaultClient,
+	}
+}
+
+// Page renders the linking status and, when linked, the request settings form.
+func (h *TwitchHandler) Page(w http.ResponseWriter, r *http.Request) {
+	reqCtx := apicontext.GetRequestContextFromRequest(r)
+	if reqCtx.User.ID == 0 {
+		RedirectToLogin(w, r, h.store)
+		return
+	}
+
+	link, err := h.repo.GetByUserID(r.Context(), reqCtx.User.ID)
+	if err != nil {
+		h.redirectWithError(w, r, "lookup_failed")
+		return
+	}
+
+	extra := map[string]interface{}{
+		"twitchEnabled": h.config.Twitch.Enabled(),
+		"twitchLinked":  link != nil,
+	}
+
+	if link != nil {
+		excluded, err := h.repo.GetExcludedUsers(r.Context(), link.TwitchID)
+		if err != nil {
+			h.redirectWithError(w, r, "lookup_failed")
+			return
+		}
+
+		extra["twitchID"] = strconv.FormatInt(link.TwitchID, 10)
+		extra["twitchUsername"] = link.TwitchUsername
+		extra["settings"] = link.Settings
+		extra["excludedUsers"] = strings.Join(excluded, "\n")
+	}
+
+	h.templates.RenderWithRequest(w, r, "settings/twitch.html", &response.TemplateData{
+		TitleBar: "Twitch",
+		Context:  reqCtx,
+		Extra:    extra,
+	})
+}
+
+// Redirect both starts the OAuth flow and consumes its callback, mirroring the
+// Discord handler. With no `code` query parameter it mints a CSRF `state`,
+// stashes it in the session and sends the user to Twitch. With a `code` it
+// validates `state`, exchanges the code, and persists the link.
+func (h *TwitchHandler) Redirect(w http.ResponseWriter, r *http.Request) {
+	reqCtx := apicontext.GetRequestContextFromRequest(r)
+	if reqCtx.User.ID == 0 {
+		RedirectToLogin(w, r, h.store)
+		return
+	}
+
+	if !h.config.Twitch.Enabled() {
+		h.redirectWithError(w, r, "not_configured")
+		return
+	}
+
+	sess, _ := h.store.Get(r, "session")
+	redirectURI := h.config.App.BaseURL + "/settings/twitch/redirect"
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		// Twitch reports user-side refusals here rather than by omitting the code.
+		if r.URL.Query().Get("error") != "" {
+			h.redirectWithError(w, r, "denied")
+			return
+		}
+
+		// Shares the CSRF-state helper used by the Discord flow in user.go.
+		state, err := randomState(16)
+		if err != nil {
+			h.redirectWithError(w, r, "oauth_init_failed")
+			return
+		}
+
+		sess.Values[twitchOAuthStateKey] = state
+		_ = sess.Save(r, w)
+
+		http.Redirect(w, r,
+			twitch.AuthorizeURL(h.config.Twitch.AppClientID, redirectURI, state),
+			http.StatusFound)
+		return
+	}
+
+	// Callback. Consume the stored state regardless of outcome so a single
+	// authorisation cannot be replayed.
+	expectedState, _ := sess.Values[twitchOAuthStateKey].(string)
+	delete(sess.Values, twitchOAuthStateKey)
+	_ = sess.Save(r, w)
+
+	if expectedState == "" || r.URL.Query().Get("state") != expectedState {
+		h.redirectWithError(w, r, "state_mismatch")
+		return
+	}
+
+	accessToken, err := twitch.ExchangeCode(
+		r.Context(), h.httpClient,
+		h.config.Twitch.AppClientID, h.config.Twitch.AppClientSecret,
+		code, redirectURI,
+	)
+	if err != nil {
+		h.redirectWithError(w, r, "token_exchange_failed")
+		return
+	}
+
+	twitchUser, err := twitch.FetchUser(r.Context(), h.httpClient, h.config.Twitch.AppClientID, accessToken)
+	if err != nil {
+		h.redirectWithError(w, r, "profile_fetch_failed")
+		return
+	}
+
+	twitchID, err := strconv.ParseInt(twitchUser.ID, 10, 64)
+	if err != nil {
+		h.redirectWithError(w, r, "profile_fetch_failed")
+		return
+	}
+
+	taken, err := h.repo.LinkedToOtherUser(r.Context(), twitchID, reqCtx.User.ID)
+	if err != nil {
+		h.redirectWithError(w, r, "link_failed")
+		return
+	}
+	if taken {
+		h.redirectWithError(w, r, "already_linked")
+		return
+	}
+
+	if err := h.repo.Link(r.Context(), reqCtx.User.ID, twitchID, strings.ToLower(twitchUser.Login)); err != nil {
+		h.redirectWithError(w, r, "link_failed")
+		return
+	}
+
+	RedirectWithMessage(w, r, h.store, "/settings/twitch?linked=1",
+		models.NewSuccess("Twitch account linked. Beatmap requests are now enabled."))
+}
+
+// Unlink removes the link. Settings and exclusions cascade with it.
+func (h *TwitchHandler) Unlink(w http.ResponseWriter, r *http.Request) {
+	reqCtx := apicontext.GetRequestContextFromRequest(r)
+	if reqCtx.User.ID == 0 {
+		RedirectToLogin(w, r, h.store)
+		return
+	}
+
+	if err := h.repo.Unlink(r.Context(), reqCtx.User.ID); err != nil {
+		h.redirectWithError(w, r, "unlink_failed")
+		return
+	}
+
+	RedirectWithMessage(w, r, h.store, "/settings/twitch",
+		models.NewSuccess("Twitch account unlinked."))
+}
+
+// UpdateSettings saves the request rules from the settings form.
+func (h *TwitchHandler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
+	reqCtx := apicontext.GetRequestContextFromRequest(r)
+	if reqCtx.User.ID == 0 {
+		RedirectToLogin(w, r, h.store)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		h.redirectWithError(w, r, "invalid_form")
+		return
+	}
+
+	if ok, _ := h.csrf.Validate(reqCtx.User.ID, r.FormValue("csrf")); !ok {
+		RedirectWithMessage(w, r, h.store, "/settings/twitch",
+			models.NewError("Your session has expired. Please try redoing what you were trying to do."))
+		return
+	}
+
+	link, err := h.repo.GetByUserID(r.Context(), reqCtx.User.ID)
+	if err != nil {
+		h.redirectWithError(w, r, "lookup_failed")
+		return
+	}
+	if link == nil {
+		h.redirectWithError(w, r, "not_linked")
+		return
+	}
+
+	settings := repositories.TwitchSettings{
+		Enabled:    r.FormValue("enabled") != "",
+		Echo:       r.FormValue("echo") != "",
+		SubOnly:    r.FormValue("sub_only") != "",
+		PointsOnly: r.FormValue("points_only") != "",
+		Cooldown:   clampInt(parseIntDefault(r.FormValue("cooldown"), 30), 0, maxCooldown),
+	}
+
+	// An unchecked star filter is stored as -1/-1, which the bot reads as "off".
+	if r.FormValue("sr_filter") != "" {
+		min := clampFloat(parseFloatDefault(r.FormValue("sr_min"), 0), 0, maxStarRating)
+		max := clampFloat(parseFloatDefault(r.FormValue("sr_max"), maxStarRating), 0, maxStarRating)
+
+		// An inverted range would reject every map. Treat it as user error and
+		// swap rather than silently disabling requests.
+		if min > max {
+			min, max = max, min
+		}
+
+		settings.StarMin = min
+		settings.StarMax = max
+	} else {
+		settings.StarMin = -1
+		settings.StarMax = -1
+	}
+
+	if err := h.repo.UpdateSettings(r.Context(), link.TwitchID, settings); err != nil {
+		h.redirectWithError(w, r, "save_failed")
+		return
+	}
+
+	if err := h.repo.ReplaceExcludedUsers(
+		r.Context(), link.TwitchID, parseExcludedUsers(r.FormValue("excluded_users")),
+	); err != nil {
+		h.redirectWithError(w, r, "save_failed")
+		return
+	}
+
+	RedirectWithMessage(w, r, h.store, "/settings/twitch",
+		models.NewSuccess("Beatmap request settings saved."))
+}
+
+func (h *TwitchHandler) redirectWithError(w http.ResponseWriter, r *http.Request, reason string) {
+	http.Redirect(w, r, "/settings/twitch?error="+reason, http.StatusFound)
+}
+
+// parseExcludedUsers turns the newline- or comma-separated textarea into a
+// deduplicated list of lowercase Twitch usernames.
+func parseExcludedUsers(raw string) []string {
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == '\n' || r == '\r' || r == ',' || r == ' ' || r == '\t'
+	})
+
+	seen := make(map[string]struct{}, len(fields))
+	users := make([]string, 0, len(fields))
+
+	for _, field := range fields {
+		name := strings.ToLower(strings.TrimPrefix(strings.TrimSpace(field), "@"))
+		if name == "" {
+			continue
+		}
+		// The column is VARCHAR(50); Twitch names top out at 25.
+		if len(name) > 50 {
+			continue
+		}
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		users = append(users, name)
+	}
+
+	return users
+}
+
+func parseIntDefault(raw string, fallback int) int {
+	value, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil {
+		return fallback
+	}
+	return value
+}
+
+func parseFloatDefault(raw string, fallback float64) float64 {
+	value, err := strconv.ParseFloat(strings.TrimSpace(raw), 64)
+	if err != nil {
+		return fallback
+	}
+	return value
+}
+
+func clampInt(value, min, max int) int {
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}
+
+func clampFloat(value, min, max float64) float64 {
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -31,8 +31,9 @@ type App struct {
 	Redis     *redis.Client
 	APIClient *api.Client
 
-	TokenRepo *repositories.TokenRepository
-	UserRepo  *repositories.UserRepository
+	TokenRepo  *repositories.TokenRepository
+	UserRepo   *repositories.UserRepository
+	TwitchRepo *repositories.TwitchRepository
 
 	AuthService    *auth.Service
 	BeatmapService *beatmap.Service
@@ -52,6 +53,7 @@ type App struct {
 	BeatmapHandler  *handlers.BeatmapHandler
 	PagesHandler    *handlers.PagesHandler
 	ErrorsHandler   *handlers.ErrorsHandler
+	TwitchHandler   *handlers.TwitchHandler
 }
 
 func New(cfg *config.Config) (*App, error) {
@@ -103,6 +105,7 @@ func (a *App) initAdapters() error {
 func (a *App) initRepositories() {
 	a.TokenRepo = repositories.NewTokenRepository(a.DB)
 	a.UserRepo = repositories.NewUserRepository(a.DB)
+	a.TwitchRepo = repositories.NewTwitchRepository(a.DB)
 }
 
 func (a *App) initServices() error {
@@ -200,6 +203,14 @@ func (a *App) initHandlers() {
 	a.PasswordHandler = handlers.NewPasswordHandler(
 		a.Config,
 		a.APIClient,
+		a.CSRF,
+		a.SessionStore,
+		a.ResponseEngine,
+	)
+
+	a.TwitchHandler = handlers.NewTwitchHandler(
+		a.Config,
+		a.TwitchRepo,
 		a.CSRF,
 		a.SessionStore,
 		a.ResponseEngine,

--- a/internal/app/routes.go
+++ b/internal/app/routes.go
@@ -59,6 +59,11 @@ func (a *App) Routes() chi.Router {
 		r.Get("/settings/discord/redirect", a.UserHandler.RedirectDiscord)
 		r.Get("/settings/discord/unlink", a.UserHandler.UnlinkDiscord)
 
+		r.Get("/settings/twitch", a.TwitchHandler.Page)
+		r.Post("/settings/twitch", a.TwitchHandler.UpdateSettings)
+		r.Get("/settings/twitch/redirect", a.TwitchHandler.Redirect)
+		r.Get("/settings/twitch/unlink", a.TwitchHandler.Unlink)
+
 		r.Get("/settings/user-page", a.UserHandler.UserpageSettingsPage)
 		r.Post("/settings/user-page", a.UserHandler.UpdateUserpage)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Database DatabaseConfig
 	Redis    RedisConfig
 	Discord  DiscordConfig
+	Twitch   TwitchConfig
 	Beatmap  BeatmapConfig
 	Security SecurityConfig
 	Links    LinksConfig
@@ -73,6 +74,20 @@ type DiscordConfig struct {
 	UserLookupURL   string
 }
 
+// TwitchConfig drives the Twitch account linking flow used by the beatmap
+// request bot. Optional: when the client ID or secret is unset, the linking page
+// reports the feature as unavailable rather than failing at boot, so existing
+// deployments keep starting without new environment variables.
+type TwitchConfig struct {
+	AppClientID     string
+	AppClientSecret string
+}
+
+// Enabled reports whether Twitch linking is configured.
+func (c TwitchConfig) Enabled() bool {
+	return c.AppClientID != "" && c.AppClientSecret != ""
+}
+
 type BeatmapConfig struct {
 	MirrorAPIURL      string
 	DownloadMirrorURL string
@@ -127,6 +142,10 @@ func Load() (*Config, error) {
 			AppClientID:     mustEnv("DISCORD_APP_CLIENT_ID"),
 			AppClientSecret: mustEnv("DISCORD_APP_CLIENT_SECRET"),
 			UserLookupURL:   mustEnv("DISCORD_USER_LOOKUP_URL"),
+		},
+		Twitch: TwitchConfig{
+			AppClientID:     optionalEnv("TWITCH_APP_CLIENT_ID", ""),
+			AppClientSecret: optionalEnv("TWITCH_APP_CLIENT_SECRET", ""),
 		},
 		Beatmap: BeatmapConfig{
 			MirrorAPIURL:      mustEnv("SOUMETSU_BEATMAP_MIRROR_API_URL"),

--- a/internal/repositories/twitch.go
+++ b/internal/repositories/twitch.go
@@ -1,0 +1,249 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/RealistikOsu/soumetsu/internal/adapters/mysql"
+)
+
+// TwitchLink is a linked Twitch channel plus the streamer's request settings.
+//
+// The schema lives in the rosu-twitch repository (migrations/0001_twitch_tables.up.sql);
+// this is the read/write side the website needs.
+type TwitchLink struct {
+	TwitchID       int64
+	TwitchUsername string
+	OsuUserID      int
+	CreatedAt      int64
+
+	Settings TwitchSettings
+}
+
+// TwitchSettings are the per-streamer request rules honoured by the bot.
+type TwitchSettings struct {
+	Enabled     bool
+	Echo        bool
+	SubOnly     bool
+	PointsOnly  bool
+	Cooldown    int
+	StarMin     float64
+	StarMax     float64
+}
+
+// DefaultTwitchSettings matches the column defaults in twitch_settings, so a link
+// with no settings row behaves identically to one with a freshly inserted row.
+func DefaultTwitchSettings() TwitchSettings {
+	return TwitchSettings{
+		Enabled:    true,
+		Echo:       true,
+		SubOnly:    false,
+		PointsOnly: false,
+		Cooldown:   30,
+		StarMin:    0,
+		StarMax:    -1,
+	}
+}
+
+type TwitchRepository struct {
+	db *mysql.DB
+}
+
+func NewTwitchRepository(db *mysql.DB) *TwitchRepository {
+	return &TwitchRepository{db: db}
+}
+
+// GetByUserID returns the link for an osu! account, or nil when unlinked.
+func (r *TwitchRepository) GetByUserID(ctx context.Context, userID int) (*TwitchLink, error) {
+	link := &TwitchLink{Settings: DefaultTwitchSettings()}
+
+	// Settings are LEFT JOINed and read into nullable holders so a link that
+	// predates its settings row still resolves, falling back to the defaults.
+	var (
+		enabled, echo, subOnly, pointsOnly sql.NullBool
+		cooldown                           sql.NullInt64
+		starMin, starMax                   sql.NullFloat64
+	)
+
+	err := r.db.QueryRowContext(ctx, `
+		SELECT  l.twitch_id,
+		        l.twitch_username,
+		        l.osu_user_id,
+		        l.created_at,
+		        s.enabled,
+		        s.echo,
+		        s.sub_only,
+		        s.points_only,
+		        s.cooldown,
+		        s.sr_min,
+		        s.sr_max
+		FROM       twitch_links    l
+		LEFT JOIN  twitch_settings s ON s.twitch_id = l.twitch_id
+		WHERE l.osu_user_id = ?
+		LIMIT 1`, userID,
+	).Scan(
+		&link.TwitchID,
+		&link.TwitchUsername,
+		&link.OsuUserID,
+		&link.CreatedAt,
+		&enabled,
+		&echo,
+		&subOnly,
+		&pointsOnly,
+		&cooldown,
+		&starMin,
+		&starMax,
+	)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if enabled.Valid {
+		link.Settings.Enabled = enabled.Bool
+	}
+	if echo.Valid {
+		link.Settings.Echo = echo.Bool
+	}
+	if subOnly.Valid {
+		link.Settings.SubOnly = subOnly.Bool
+	}
+	if pointsOnly.Valid {
+		link.Settings.PointsOnly = pointsOnly.Bool
+	}
+	if cooldown.Valid {
+		link.Settings.Cooldown = int(cooldown.Int64)
+	}
+	if starMin.Valid {
+		link.Settings.StarMin = starMin.Float64
+	}
+	if starMax.Valid {
+		link.Settings.StarMax = starMax.Float64
+	}
+
+	return link, nil
+}
+
+// LinkedToOtherUser reports whether a Twitch account is already claimed by a
+// different osu! account. twitch_links has unique keys on both sides, so this
+// exists purely to turn a would-be constraint violation into a clear message.
+func (r *TwitchRepository) LinkedToOtherUser(ctx context.Context, twitchID int64, userID int) (bool, error) {
+	var owner int
+	err := r.db.QueryRowContext(ctx,
+		"SELECT osu_user_id FROM twitch_links WHERE twitch_id = ? LIMIT 1", twitchID).Scan(&owner)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return owner != userID, nil
+}
+
+// Link creates or replaces the link for an osu! account and ensures a settings
+// row exists for it.
+func (r *TwitchRepository) Link(ctx context.Context, userID int, twitchID int64, twitchUsername string) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	// Relinking to a different channel must not leave the previous row behind:
+	// the unique key on osu_user_id would reject the insert.
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM twitch_links WHERE osu_user_id = ?", userID); err != nil {
+		return err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO twitch_links (twitch_id, twitch_username, osu_user_id, created_at)
+		VALUES (?, ?, ?, ?)
+		ON DUPLICATE KEY UPDATE
+			twitch_username = VALUES(twitch_username),
+			osu_user_id     = VALUES(osu_user_id)`,
+		twitchID, twitchUsername, userID, time.Now().Unix()); err != nil {
+		return err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT IGNORE INTO twitch_settings (twitch_id) VALUES (?)`, twitchID); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+// Unlink removes the link. twitch_settings and twitch_excluded_users cascade.
+func (r *TwitchRepository) Unlink(ctx context.Context, userID int) error {
+	_, err := r.db.ExecContext(ctx, "DELETE FROM twitch_links WHERE osu_user_id = ?", userID)
+	return err
+}
+
+// UpdateSettings writes the streamer's request rules.
+func (r *TwitchRepository) UpdateSettings(ctx context.Context, twitchID int64, s TwitchSettings) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO twitch_settings
+			(twitch_id, enabled, echo, sub_only, points_only, cooldown, sr_min, sr_max)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON DUPLICATE KEY UPDATE
+			enabled     = VALUES(enabled),
+			echo        = VALUES(echo),
+			sub_only    = VALUES(sub_only),
+			points_only = VALUES(points_only),
+			cooldown    = VALUES(cooldown),
+			sr_min      = VALUES(sr_min),
+			sr_max      = VALUES(sr_max)`,
+		twitchID, s.Enabled, s.Echo, s.SubOnly, s.PointsOnly, s.Cooldown, s.StarMin, s.StarMax)
+	return err
+}
+
+// GetExcludedUsers returns the Twitch usernames barred from requesting.
+func (r *TwitchRepository) GetExcludedUsers(ctx context.Context, twitchID int64) ([]string, error) {
+	rows, err := r.db.QueryContext(ctx,
+		"SELECT excluded_username FROM twitch_excluded_users WHERE twitch_id = ? ORDER BY excluded_username",
+		twitchID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var users []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		users = append(users, name)
+	}
+	return users, rows.Err()
+}
+
+// ReplaceExcludedUsers swaps the exclusion list wholesale, which is how the
+// settings form submits it.
+func (r *TwitchRepository) ReplaceExcludedUsers(ctx context.Context, twitchID int64, usernames []string) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM twitch_excluded_users WHERE twitch_id = ?", twitchID); err != nil {
+		return err
+	}
+
+	for _, name := range usernames {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT IGNORE INTO twitch_excluded_users (twitch_id, excluded_username)
+			VALUES (?, ?)`, twitchID, name); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}

--- a/internal/repositories/twitch.go
+++ b/internal/repositories/twitch.go
@@ -23,13 +23,13 @@ type TwitchLink struct {
 
 // TwitchSettings are the per-streamer request rules honoured by the bot.
 type TwitchSettings struct {
-	Enabled     bool
-	Echo        bool
-	SubOnly     bool
-	PointsOnly  bool
-	Cooldown    int
-	StarMin     float64
-	StarMax     float64
+	Enabled    bool
+	Echo       bool
+	SubOnly    bool
+	PointsOnly bool
+	Cooldown   int
+	StarMin    float64
+	StarMax    float64
 }
 
 // DefaultTwitchSettings matches the column defaults in twitch_settings, so a link

--- a/web/templates/settings/menu.html
+++ b/web/templates/settings/menu.html
@@ -35,6 +35,12 @@ NoCompile=true
 				<span>Discord Linking</span>
 			</a>
 
+			<a href="/settings/twitch"
+				class="flex items-center gap-3 px-4 py-3 rounded-lg transition-colors {{ if eq .Path "/settings/twitch" }}bg-primary/20 text-primary border-l-4 border-primary{{ else }}text-gray-300 hover:bg-dark-bg{{ end }}">
+				<i class="fab fa-twitch w-5"></i>
+				<span>Twitch Requests</span>
+			</a>
+
 			{{/* Supporter only features */}}
 			{{ if has .Context.User.Privileges 4 }}
 				<div class="border-t border-dark-border my-2"></div>

--- a/web/templates/settings/twitch.html
+++ b/web/templates/settings/twitch.html
@@ -1,0 +1,280 @@
+{{/*###
+KyutGrill=settings2.jpg
+Include=menu.html
+DisableHH=true
+*/}}
+{{ define "tpl" }}
+{{ $enabled := get .Extra "twitchEnabled" }}
+{{ $isLinked := get .Extra "twitchLinked" }}
+{{ $twitchID := get .Extra "twitchID" }}
+{{ $twitchUsername := get .Extra "twitchUsername" }}
+{{ $settings := get .Extra "settings" }}
+{{ $excluded := get .Extra "excludedUsers" }}
+
+<div class="relative min-h-screen py-8">
+	<div class="fixed inset-0 -z-10">
+		<div class="absolute inset-0 bg-cover bg-center bg-no-repeat opacity-20"
+			style="background-image: url('/static/headers/settings2.jpg');"></div>
+		<div class="absolute inset-0 bg-gradient-to-b from-dark-bg via-dark-bg/90 to-dark-bg"></div>
+	</div>
+
+	<div class="container mx-auto px-4">
+		<div class="flex flex-col md:flex-row gap-6">
+			{{ template "settingsSidebar" . }}
+
+			<div class="flex-1 space-y-6">
+				<div class="card">
+					<div class="flex items-center gap-3 mb-6 pb-4 border-b border-dark-border">
+						<div class="w-12 h-12 bg-purple-500/20 rounded-full flex items-center justify-center">
+							<i class="fab fa-twitch text-purple-400 text-xl"></i>
+						</div>
+						<div>
+							<h2 class="text-2xl font-display font-bold text-white">Twitch Beatmap Requests</h2>
+							<p class="text-sm text-gray-400">Let your viewers send you maps in-game</p>
+						</div>
+					</div>
+
+					{{ if .QueryParams.linked }}
+						<div class="mb-6 p-4 bg-green-900/30 border border-green-700/50 rounded-lg flex items-start gap-3">
+							<i class="fas fa-check-circle text-green-400 mt-1"></i>
+							<p class="text-sm text-gray-200">Your Twitch account has been linked.</p>
+						</div>
+					{{ end }}
+
+					{{ if .QueryParams.error }}
+						<div class="mb-6 p-4 bg-red-900/30 border border-red-700/50 rounded-lg flex items-start gap-3">
+							<i class="fas fa-exclamation-circle text-red-400 mt-1"></i>
+							<p class="text-sm text-gray-200">
+								{{ if eq .QueryParams.error "state_mismatch" }}OAuth state mismatch — please try linking again.
+								{{ else if eq .QueryParams.error "token_exchange_failed" }}Twitch rejected the authorisation code. Please try again.
+								{{ else if eq .QueryParams.error "profile_fetch_failed" }}Could not fetch your Twitch profile. Please try again.
+								{{ else if eq .QueryParams.error "already_linked" }}That Twitch account is already linked to another player.
+								{{ else if eq .QueryParams.error "link_failed" }}Failed to link your Twitch account.
+								{{ else if eq .QueryParams.error "unlink_failed" }}Failed to unlink your Twitch account.
+								{{ else if eq .QueryParams.error "oauth_init_failed" }}Could not start the Twitch linking flow.
+								{{ else if eq .QueryParams.error "not_configured" }}Twitch linking is not configured on this server.
+								{{ else if eq .QueryParams.error "not_linked" }}You need to link a Twitch account first.
+								{{ else if eq .QueryParams.error "denied" }}You cancelled the Twitch authorisation.
+								{{ else if eq .QueryParams.error "save_failed" }}Could not save your settings. Please try again.
+								{{ else if eq .QueryParams.error "invalid_form" }}That form submission could not be read.
+								{{ else }}Something went wrong while talking to Twitch.
+								{{ end }}
+							</p>
+						</div>
+					{{ end }}
+
+					{{ if not $enabled }}
+						<div class="p-4 bg-orange-900/20 border border-orange-700/50 rounded-lg flex items-start gap-3">
+							<i class="fas fa-plug text-orange-400 mt-1"></i>
+							<div>
+								<p class="text-orange-400 font-medium">Not available</p>
+								<p class="text-sm text-gray-400">Twitch linking has not been configured on this server yet.</p>
+							</div>
+						</div>
+					{{ else if $isLinked }}
+						<div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+							<div class="space-y-6">
+								<div class="text-center p-6 bg-dark-bg rounded-lg border border-dark-border">
+									<div class="relative inline-block mb-4">
+										<div class="w-24 h-24 rounded-full border-4 border-purple-500 shadow-lg bg-purple-500/20 flex items-center justify-center">
+											<i class="fab fa-twitch text-purple-400 text-4xl"></i>
+										</div>
+										<div class="absolute -bottom-1 -right-1 w-8 h-8 bg-green-500 rounded-full border-4 border-dark-bg flex items-center justify-center">
+											<i class="fas fa-check text-white text-xs"></i>
+										</div>
+									</div>
+									<h3 class="text-xl font-bold text-white">
+										<a href="https://twitch.tv/{{ $twitchUsername }}" target="_blank" rel="noopener noreferrer"
+											class="hover:text-purple-400 transition-colors">{{ $twitchUsername }}</a>
+									</h3>
+									<p class="text-xs text-gray-500 mt-1 font-mono">ID: {{ $twitchID }}</p>
+								</div>
+
+								<div class="p-4 bg-dark-bg rounded-lg border border-dark-border">
+									<h4 class="text-sm font-medium text-gray-400 mb-3 flex items-center gap-2">
+										<i class="fas fa-info-circle"></i>
+										How it works
+									</h4>
+									<ul class="space-y-2 text-sm text-gray-400">
+										<li class="flex items-start gap-2">
+											<i class="fas fa-check text-green-400 mt-1 text-xs"></i>
+											<span>The bot joins your chat automatically while you are live.</span>
+										</li>
+										<li class="flex items-start gap-2">
+											<i class="fas fa-check text-green-400 mt-1 text-xs"></i>
+											<span>Viewers post a beatmap link; you receive it in-game.</span>
+										</li>
+										<li class="flex items-start gap-2">
+											<i class="fas fa-check text-green-400 mt-1 text-xs"></i>
+											<span>Mods written after the link (<code>+HDDT</code>) are passed along.</span>
+										</li>
+									</ul>
+								</div>
+
+								<div class="p-4 bg-red-900/20 border border-red-700/50 rounded-lg">
+									<h4 class="text-red-300 font-medium mb-2 flex items-center gap-2">
+										<i class="fas fa-unlink"></i>
+										Unlink Account
+									</h4>
+									<p class="text-sm text-gray-400 mb-4">Stop receiving beatmap requests and remove the link.</p>
+									<a href="/settings/twitch/unlink" class="btn-secondary bg-red-600/20 border-red-500/50 hover:bg-red-600/30 inline-flex items-center gap-2">
+										<i class="fab fa-twitch"></i>
+										Unlink Twitch
+									</a>
+								</div>
+							</div>
+
+							<div>
+								<form action="/settings/twitch" method="POST" class="space-y-5">
+									{{ ieForm .Context }}
+
+									<h4 class="text-sm font-medium text-gray-400 flex items-center gap-2">
+										<i class="fas fa-sliders-h"></i>
+										Request Settings
+									</h4>
+
+									<label class="flex items-start gap-3 p-3 bg-dark-bg rounded-lg border border-dark-border cursor-pointer">
+										<input type="checkbox" name="enabled" value="1" class="mt-1" {{ if $settings.Enabled }}checked{{ end }}>
+										<span>
+											<span class="block text-white font-medium">Accept requests</span>
+											<span class="block text-sm text-gray-400">Turn this off to pause requests without unlinking.</span>
+										</span>
+									</label>
+
+									<label class="flex items-start gap-3 p-3 bg-dark-bg rounded-lg border border-dark-border cursor-pointer">
+										<input type="checkbox" name="echo" value="1" class="mt-1" {{ if $settings.Echo }}checked{{ end }}>
+										<span>
+											<span class="block text-white font-medium">Confirm in chat</span>
+											<span class="block text-sm text-gray-400">Reply in Twitch chat when a request goes through.</span>
+										</span>
+									</label>
+
+									<label class="flex items-start gap-3 p-3 bg-dark-bg rounded-lg border border-dark-border cursor-pointer">
+										<input type="checkbox" name="sub_only" value="1" class="mt-1" {{ if $settings.SubOnly }}checked{{ end }}>
+										<span>
+											<span class="block text-white font-medium">Subscribers only</span>
+											<span class="block text-sm text-gray-400">Mods and VIPs can always request.</span>
+										</span>
+									</label>
+
+									<label class="flex items-start gap-3 p-3 bg-dark-bg rounded-lg border border-dark-border cursor-pointer">
+										<input type="checkbox" name="points_only" value="1" class="mt-1" {{ if $settings.PointsOnly }}checked{{ end }}>
+										<span>
+											<span class="block text-white font-medium">Channel points only</span>
+											<span class="block text-sm text-gray-400">Requests must be redeemed with a channel point reward.</span>
+										</span>
+									</label>
+
+									<div class="p-3 bg-dark-bg rounded-lg border border-dark-border">
+										<label for="cooldown" class="block text-white font-medium mb-1">Cooldown per viewer</label>
+										<p class="text-sm text-gray-400 mb-2">Seconds a viewer must wait between requests. 0 disables it.</p>
+										<input type="number" id="cooldown" name="cooldown" min="0" max="3600"
+											value="{{ $settings.Cooldown }}"
+											class="w-full bg-dark-card border border-dark-border rounded px-3 py-2 text-white">
+									</div>
+
+									<div class="p-3 bg-dark-bg rounded-lg border border-dark-border">
+										<label class="flex items-start gap-3 cursor-pointer mb-3">
+											<input type="checkbox" name="sr_filter" value="1" class="mt-1"
+												{{ if ge $settings.StarMax 0.0 }}checked{{ end }}>
+											<span>
+												<span class="block text-white font-medium">Limit star rating</span>
+												<span class="block text-sm text-gray-400">Reject maps outside this range.</span>
+											</span>
+										</label>
+										<div class="grid grid-cols-2 gap-3">
+											<div>
+												<label for="sr_min" class="block text-xs text-gray-400 mb-1">Minimum</label>
+												<input type="number" id="sr_min" name="sr_min" step="0.1" min="0" max="20"
+													value="{{ if ge $settings.StarMin 0.0 }}{{ $settings.StarMin }}{{ else }}0{{ end }}"
+													class="w-full bg-dark-card border border-dark-border rounded px-3 py-2 text-white">
+											</div>
+											<div>
+												<label for="sr_max" class="block text-xs text-gray-400 mb-1">Maximum</label>
+												<input type="number" id="sr_max" name="sr_max" step="0.1" min="0" max="20"
+													value="{{ if ge $settings.StarMax 0.0 }}{{ $settings.StarMax }}{{ else }}10{{ end }}"
+													class="w-full bg-dark-card border border-dark-border rounded px-3 py-2 text-white">
+											</div>
+										</div>
+									</div>
+
+									<div class="p-3 bg-dark-bg rounded-lg border border-dark-border">
+										<label for="excluded_users" class="block text-white font-medium mb-1">Blocked viewers</label>
+										<p class="text-sm text-gray-400 mb-2">Twitch usernames that may never request. One per line.</p>
+										<textarea id="excluded_users" name="excluded_users" rows="4"
+											class="w-full bg-dark-card border border-dark-border rounded px-3 py-2 text-white font-mono text-sm">{{ $excluded }}</textarea>
+									</div>
+
+									<button type="submit" class="btn-primary bg-purple-600 hover:bg-purple-700 inline-flex items-center gap-2">
+										<i class="fas fa-save"></i>
+										Save Settings
+									</button>
+								</form>
+							</div>
+						</div>
+					{{ else }}
+						<div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+							<div class="space-y-6">
+								<div class="text-center p-6 bg-dark-bg rounded-lg border border-dark-border">
+									<div class="relative inline-block mb-4">
+										<div class="w-24 h-24 rounded-full bg-purple-500/20 border-4 border-dashed border-purple-500/50 flex items-center justify-center">
+											<i class="fab fa-twitch text-4xl text-purple-400"></i>
+										</div>
+									</div>
+									<h3 class="text-xl font-bold text-white">Not Connected</h3>
+									<p class="text-sm text-gray-400 mt-1">Link your Twitch channel</p>
+								</div>
+
+								<div class="p-4 bg-orange-900/20 border border-orange-700/50 rounded-lg">
+									<div class="flex items-center gap-3">
+										<div class="w-10 h-10 bg-orange-500/20 rounded-full flex items-center justify-center">
+											<i class="fas fa-exclamation text-orange-400"></i>
+										</div>
+										<div>
+											<p class="text-orange-400 font-medium">Not Linked</p>
+											<p class="text-sm text-gray-400">Connect to receive beatmap requests</p>
+										</div>
+									</div>
+								</div>
+							</div>
+
+							<div class="space-y-6">
+								<div class="p-4 bg-dark-bg rounded-lg border border-dark-border">
+									<h4 class="text-sm font-medium text-gray-400 mb-3 flex items-center gap-2">
+										<i class="fas fa-info-circle"></i>
+										What this does
+									</h4>
+									<ul class="space-y-2 text-sm text-gray-400">
+										<li class="flex items-start gap-2">
+											<i class="fas fa-check text-green-400 mt-1 text-xs"></i>
+											<span>Viewers request maps by posting a link in your Twitch chat.</span>
+										</li>
+										<li class="flex items-start gap-2">
+											<i class="fas fa-check text-green-400 mt-1 text-xs"></i>
+											<span>Requests arrive as an in-game message from the server bot.</span>
+										</li>
+										<li class="flex items-start gap-2">
+											<i class="fas fa-check text-green-400 mt-1 text-xs"></i>
+											<span>Filter by star rating, subscriber status or channel points.</span>
+										</li>
+									</ul>
+								</div>
+
+								<div class="p-6 bg-gradient-to-br from-purple-900/30 to-fuchsia-900/30 border border-purple-700/50 rounded-lg text-center">
+									<i class="fab fa-twitch text-5xl text-purple-400 mb-4"></i>
+									<h4 class="text-lg font-bold text-white mb-2">Connect with Twitch</h4>
+									<p class="text-sm text-gray-400 mb-4">Link your channel to get started</p>
+									<a href="/settings/twitch/redirect" class="btn-primary bg-purple-600 hover:bg-purple-700 inline-flex items-center gap-2">
+										<i class="fab fa-twitch"></i>
+										Link Twitch Account
+									</a>
+								</div>
+							</div>
+						</div>
+					{{ end }}
+				</div>
+			</div>
+		</div>
+	</div>
+</div>
+{{ end }}


### PR DESCRIPTION
Adds `/settings/twitch`, where a player links their Twitch channel for the beatmap request bot and configures their request rules.

Companion to the IRC gateway in `RealistikOsu.Bancho` and the bot itself.

## What it does

- Twitch OAuth link / unlink
- Per-streamer settings form: enabled, echo to chat, sub-only, channel-points-only, cooldown, star rating window, blocked viewers
- Writes `twitch_links`, `twitch_settings`, `twitch_excluded_users` (schema ships with the bot)

## Notes

**OAuth `state` is verified.** It is generated, stashed in the session, and consumed on callback whatever the outcome, so a callback cannot be forged or replayed.

**Config is optional.** The Twitch client ID and secret are read with the non-fatal env helper rather than the panicking one — using the strict helper would have stopped every existing deployment from booting on restart. With them unset, the page reports the feature as unavailable.

**CSRF is validated** on the settings POST, matching every other form in the codebase.

## Setup

Create an app at https://dev.twitch.tv/console/apps with its OAuth redirect URL set to `<base-url>/settings/twitch/redirect`, then set:

```
TWITCH_APP_CLIENT_ID=
TWITCH_APP_CLIENT_SECRET=
```

## Testing

Builds clean and all templates parse (verified with a temporary harness, since a template syntax error would otherwise only surface on first page load). **Not exercised against a live database or a real Twitch app yet.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
